### PR TITLE
Improved design by refactoring the code. No changes in functionality

### DIFF
--- a/StGenericVertexMaker/Minuit/StMinuitVertexFinder.cxx
+++ b/StGenericVertexMaker/Minuit/StMinuitVertexFinder.cxx
@@ -830,9 +830,7 @@ void StMinuitVertexFinder::UseVertexConstraint(Double_t x0, Double_t y0, Double_
   double mY0 = sBeamline.y0;
   double mdxdz = sBeamline.dxdz;
   double mdydz = sBeamline.dydz;
-  mWeight = weight;
   LOG_INFO << "StMinuitVertexFinder::Using Constrained Vertex" << endm;
-  LOG_INFO << "weight in fit = " << weight <<  endm;
   StThreeVectorD origin(mX0,mY0,0.0);
   Double_t pt  = 88889999;   
   Double_t nxy=::sqrt(mdxdz*mdxdz +  mdydz*mdydz);

--- a/StGenericVertexMaker/Minuit/StMinuitVertexFinder.cxx
+++ b/StGenericVertexMaker/Minuit/StMinuitVertexFinder.cxx
@@ -820,7 +820,7 @@ StMinuitVertexFinder::printInfo(ostream& os) const
     os << "final potential width scale .... " << mWidthScale << endl;
 }
 
-void StMinuitVertexFinder::UseVertexConstraint(Double_t x0, Double_t y0, Double_t dxdz, Double_t dydz, Double_t weight) {
+void StMinuitVertexFinder::UseVertexConstraint() {
 
   // Historically, this method was designed for a 1D fit with beamline
   // So, we'll keep it this way for backward compatibility

--- a/StGenericVertexMaker/Minuit/StMinuitVertexFinder.cxx
+++ b/StGenericVertexMaker/Minuit/StMinuitVertexFinder.cxx
@@ -27,10 +27,6 @@ vector<UShort_t>           StMinuitVertexFinder::mHelixFlags;
 vector<Double_t >          StMinuitVertexFinder::mSigma;
 vector<Double_t >          StMinuitVertexFinder::mZImpact;
 Double_t                   StMinuitVertexFinder::mWidthScale = 0.1; // 1./TMath::Sqrt(5.);
-Double_t                   StMinuitVertexFinder::mX0;
-Double_t                   StMinuitVertexFinder::mY0;
-Double_t                   StMinuitVertexFinder::mdxdz;
-Double_t                   StMinuitVertexFinder::mdydz;
 Bool_t                     StMinuitVertexFinder::requireCTB;
 Int_t                      StMinuitVertexFinder::nCTBHits;
 //==========================================================
@@ -830,16 +826,12 @@ void StMinuitVertexFinder::UseVertexConstraint(Double_t x0, Double_t y0, Double_
   // So, we'll keep it this way for backward compatibility
   if (mVertexFitMode != VertexFit_t::Beamline1D) return;
 
-  mX0 = x0;
-  mY0 = y0;
-  mdxdz = dxdz;
-  mdydz = dydz;
+  double mX0 = sBeamline.x0;
+  double mY0 = sBeamline.y0;
+  double mdxdz = sBeamline.dxdz;
+  double mdydz = sBeamline.dydz;
   mWeight = weight;
   LOG_INFO << "StMinuitVertexFinder::Using Constrained Vertex" << endm;
-  LOG_INFO << "x origin = " << mX0 << endm;
-  LOG_INFO << "y origin = " << mY0 << endm;
-  LOG_INFO << "slope dxdz = " << mdxdz << endm;
-  LOG_INFO << "slope dydz = " << mdydz << endm;
   LOG_INFO << "weight in fit = " << weight <<  endm;
   StThreeVectorD origin(mX0,mY0,0.0);
   Double_t pt  = 88889999;   

--- a/StGenericVertexMaker/Minuit/StMinuitVertexFinder.cxx
+++ b/StGenericVertexMaker/Minuit/StMinuitVertexFinder.cxx
@@ -13,10 +13,6 @@
 #include "StEventTypes.h"
 #include "StEnumerations.h"
 #include "TMinuit.h"
-#if 0
-#include "TH1K.h"
-#include "TSpectrum.h"
-#endif
 #include "StGlobals.hh"
 #include "SystemOfUnits.h"
 #include "StCtbMatcher.h"

--- a/StGenericVertexMaker/Minuit/StMinuitVertexFinder.h
+++ b/StGenericVertexMaker/Minuit/StMinuitVertexFinder.h
@@ -179,10 +179,6 @@ private:
     static Bool_t                   requireCTB;
     static Int_t                    nCTBHits;
     static Double_t                 mWidthScale;
-    static Double_t                 mX0  ; // starting point of beam parameterization
-    static Double_t                 mY0  ; // starting point of beam parameterization
-    static Double_t                 mdxdz; // beam slope
-    static Double_t                 mdydz; // beam slope
     Int_t                    mStatusMin;           // Minuit status flag 
     StThreeVectorD           mExternalSeed;
     Bool_t                   mExternalSeedPresent;

--- a/StGenericVertexMaker/Minuit/StMinuitVertexFinder.h
+++ b/StGenericVertexMaker/Minuit/StMinuitVertexFinder.h
@@ -143,7 +143,7 @@ private:
     void    calculateRanks();
     Int_t   findSeeds();
 
-    virtual void    UseVertexConstraint(Double_t x0, Double_t y0, Double_t dxdz, Double_t dydz, Double_t weight);
+    virtual void UseVertexConstraint();
 
     static void fcn(Int_t&, Double_t*, Double_t&, Double_t*, Int_t); // fit function
     static void fcn1D(Int_t&, Double_t*, Double_t&, Double_t*, Int_t); // fit function

--- a/StGenericVertexMaker/Minuit/StMinuitVertexFinder.h
+++ b/StGenericVertexMaker/Minuit/StMinuitVertexFinder.h
@@ -112,7 +112,6 @@ public:
     virtual        ~StMinuitVertexFinder();
     Int_t           fit(StEvent*);       
     void            printInfo(ostream& = cout) const;
-    void            UseVertexConstraint(Double_t x0, Double_t y0, Double_t dxdz, Double_t dydz, Double_t weight);
     virtual void    InitRun  (Int_t runumber);
     void            Clear();
 
@@ -143,6 +142,8 @@ private:
     Int_t   checkCrossMembrane(const StTrack *);
     void    calculateRanks();
     Int_t   findSeeds();
+
+    virtual void    UseVertexConstraint(Double_t x0, Double_t y0, Double_t dxdz, Double_t dydz, Double_t weight);
 
     static void fcn(Int_t&, Double_t*, Double_t&, Double_t*, Int_t); // fit function
     static void fcn1D(Int_t&, Double_t*, Double_t&, Double_t*, Int_t); // fit function

--- a/StGenericVertexMaker/Minuit/StMinuitVertexFinder.h
+++ b/StGenericVertexMaker/Minuit/StMinuitVertexFinder.h
@@ -156,7 +156,6 @@ private:
     bool                   mRequireCTB;       // Set maker to use CTB
     UInt_t                 mMinNumberOfFitPointsOnTrack;
     Float_t                mDcaZMax;
-    Double_t               mWeight ;          // Weight in fit for vertex contraint
     Double_t               mRImpactMax;       // Max distance between helix and nominal beamline (0,0,z)
     Int_t                  mMinTrack;         // Min number of tracks
     Float_t                mZMin;             // Min z of possible vertex positions

--- a/StGenericVertexMaker/StFixedVertexFinder.cxx
+++ b/StGenericVertexMaker/StFixedVertexFinder.cxx
@@ -71,7 +71,7 @@ void StFixedVertexFinder::printInfo(ostream& os)const{
     os << "Fixed position: x=" << mFixedX << " y=" << mFixedY << " z=" << mFixedZ << endl;
 }
 
-void StFixedVertexFinder::UseVertexConstraint(double x0, double y0, double dxdz, double dydz, double weight){
+void StFixedVertexFinder::UseVertexConstraint(){
     LOG_WARN << "StFixedVertexFinder::UseVertexConstraint() - vertex beam constraint NOT implemented in context of fixed vertex finder" << endm;
 
 }

--- a/StGenericVertexMaker/StFixedVertexFinder.h
+++ b/StGenericVertexMaker/StFixedVertexFinder.h
@@ -37,11 +37,6 @@ public:
     // mandatory implementations
     int fit(StEvent*);
     void printInfo(ostream& = cout)const;
-    /**
-     * Vertex constraint not useful for this VF but is part of base class so implementation just
-     * displays warning to this effect
-     */
-    void UseVertexConstraint(double x0, double y0, double dxdz, double dydz, double weight);
 
     
     // member not from base class
@@ -52,6 +47,12 @@ private:
     Double_t mFixedX; //!< X co-ordinate of vertex
     Double_t mFixedY; //!< Y co-ordinate of vertex
     Double_t mFixedZ; //!< Z co-ordinate of vertex
+
+    /**
+     * Vertex constraint not useful for this VF but is part of base class so implementation just
+     * displays warning to this effect
+     */
+    virtual void UseVertexConstraint(double x0, double y0, double dxdz, double dydz, double weight);
 
 };
 

--- a/StGenericVertexMaker/StFixedVertexFinder.h
+++ b/StGenericVertexMaker/StFixedVertexFinder.h
@@ -52,7 +52,7 @@ private:
      * Vertex constraint not useful for this VF but is part of base class so implementation just
      * displays warning to this effect
      */
-    virtual void UseVertexConstraint(double x0, double y0, double dxdz, double dydz, double weight);
+    virtual void UseVertexConstraint();
 
 };
 

--- a/StGenericVertexMaker/StGenericVertexFinder.cxx
+++ b/StGenericVertexMaker/StGenericVertexFinder.cxx
@@ -272,16 +272,19 @@ void StGenericVertexFinder::UseVertexConstraint(const vertexSeed_st& beamline)
 {
    sBeamline = beamline;
 
+   LOG_INFO << "BeamLine constraint: weight =  " << sBeamline.weight << "\n"
+            << "x(z) = (" << sBeamline.x0   << " +/- max(0.01, "   << sBeamline.err_x0 << ") ) + "
+            <<        "(" << sBeamline.dxdz << " +/- max(0.0001, " << sBeamline.err_dxdz << ") ) * z\n"
+            << "y(z) = (" << sBeamline.y0   << " +/- max(0.01, "   << sBeamline.err_y0 << ") ) + "
+            <<        "(" << sBeamline.dydz << " +/- max(0.0001, " << sBeamline.err_dydz << ") ) * z"
+            << endm;
+
    sBeamline.err_x0 = std::max(0.01f, sBeamline.err_x0);
    sBeamline.err_y0 = std::max(0.01f, sBeamline.err_y0);
 
    // 0.0001f radians corresponds to a 0.1mm arc at 1m = 1000mm length
    sBeamline.err_dxdz = std::max(0.0001f, sBeamline.err_dxdz);
    sBeamline.err_dydz = std::max(0.0001f, sBeamline.err_dydz);
-
-   LOG_INFO << "BeamLine constraint: weight =  " << sBeamline.weight << endm;
-   LOG_INFO << "x(z) = (" << sBeamline.x0 << " +/- " << sBeamline.err_x0 << ") + (" << sBeamline.dxdz << " +/- " << sBeamline.err_dxdz << ") * z" << endm;
-   LOG_INFO << "y(z) = (" << sBeamline.y0 << " +/- " << sBeamline.err_y0 << ") + (" << sBeamline.dydz << " +/- " << sBeamline.err_dydz << ") * z" << endm;
 }
 
 

--- a/StGenericVertexMaker/StGenericVertexFinder.cxx
+++ b/StGenericVertexMaker/StGenericVertexFinder.cxx
@@ -286,7 +286,7 @@ void StGenericVertexFinder::UseVertexConstraint(const vertexSeed_st& beamline)
    sBeamline.err_dxdz = std::max(0.0001f, sBeamline.err_dxdz);
    sBeamline.err_dydz = std::max(0.0001f, sBeamline.err_dydz);
 
-   UseVertexConstraint(sBeamline.x0,sBeamline.y0,sBeamline.dxdz,sBeamline.dydz,0.0001);
+   UseVertexConstraint();
 }
 
 

--- a/StGenericVertexMaker/StGenericVertexFinder.cxx
+++ b/StGenericVertexMaker/StGenericVertexFinder.cxx
@@ -285,6 +285,8 @@ void StGenericVertexFinder::UseVertexConstraint(const vertexSeed_st& beamline)
    // 0.0001f radians corresponds to a 0.1mm arc at 1m = 1000mm length
    sBeamline.err_dxdz = std::max(0.0001f, sBeamline.err_dxdz);
    sBeamline.err_dydz = std::max(0.0001f, sBeamline.err_dydz);
+
+   UseVertexConstraint(sBeamline.x0,sBeamline.y0,sBeamline.dxdz,sBeamline.dydz,0.0001);
 }
 
 

--- a/StGenericVertexMaker/StGenericVertexFinder.h
+++ b/StGenericVertexMaker/StGenericVertexFinder.h
@@ -70,7 +70,7 @@ class StGenericVertexFinder {
  private:
   vector<StPrimaryVertex> mVertexList;      // Holds all found prim veritcess
 
-  virtual void           UseVertexConstraint(double, double, double, double, double)=0;
+  virtual void           UseVertexConstraint()=0;
 
  protected: //................................
   StPrimaryVertexOrder   mVertexOrderMethod; // will default to 0 i.e. orderByNumberOfDaughters

--- a/StGenericVertexMaker/StGenericVertexFinder.h
+++ b/StGenericVertexMaker/StGenericVertexFinder.h
@@ -39,7 +39,6 @@ class StGenericVertexFinder {
   StPrimaryVertex*       getVertex(int idx) const;
   void                   addVertex(StPrimaryVertex*);
   int                    size() const;
-  virtual void           UseVertexConstraint(double, double, double, double, double)=0;
           void           UseVertexConstraint(const vertexSeed_st& beamline);
           void           NoVertexConstraint();
           int            IsVertexConstraint() const {return mVertexConstrain;}
@@ -70,6 +69,8 @@ class StGenericVertexFinder {
 
  private:
   vector<StPrimaryVertex> mVertexList;      // Holds all found prim veritcess
+
+  virtual void           UseVertexConstraint(double, double, double, double, double)=0;
 
  protected: //................................
   StPrimaryVertexOrder   mVertexOrderMethod; // will default to 0 i.e. orderByNumberOfDaughters

--- a/StGenericVertexMaker/StGenericVertexFinder.h
+++ b/StGenericVertexMaker/StGenericVertexFinder.h
@@ -53,17 +53,17 @@ class StGenericVertexFinder {
 
   // General (default)
   virtual void           SetMode(Int_t mode=0 ) {mMode = mode;}
-  virtual int            GetMode() const 	{return mMode;}
+  virtual int            GetMode() const        {return mMode;}
           void           SetDebugLevel(Int_t level) {mDebugLevel=level;}
   virtual void           Init(){ /* noop */;}
   virtual void           Finish(){ /* noop */;}
   virtual void           InitRun  (int runumber){ /* noop */;}
   virtual void           Clear();
-  const std::vector<StPrimaryVertex> *result() {return &mVertexList;} 
- 
+  const std::vector<StPrimaryVertex> *result() {return &mVertexList;}
+
   void                   FillStEvent(StEvent*);
   virtual void SetVertexPosition(double x,double y,double z){assert(0);}
-  virtual int            IsFixed() const 	{return 0;}
+  virtual int            IsFixed() const        {return 0;}
  protected: //................................
 
   StGenericVertexFinder(VertexFit_t fitMode=VertexFit_t::Unspecified);
@@ -80,7 +80,7 @@ class StGenericVertexFinder {
   VertexFit_t            mVertexFitMode;
 
   int                    mDebugLevel;
-  bool   		 mIsMC;              // flag minor differences between Data & M-C
+  bool                   mIsMC;              // flag minor differences between Data & M-C
   bool                   mUseBtof;           // default use btof = false
   bool                   mUseCtb;            // default use ctb = false
 

--- a/StGenericVertexMaker/StGenericVertexMaker.cxx
+++ b/StGenericVertexMaker/StGenericVertexMaker.cxx
@@ -276,7 +276,6 @@ Int_t StGenericVertexMaker::Make()
 {
   nEvTotal++;
   primV  = NULL;
-  mEvent = NULL;
   mEvent = (StEvent *)GetInputDS("StEvent");
   LOG_DEBUG << "StGenericVertexMaker::Make: StEvent pointer " << mEvent << endm;
   LOG_DEBUG << "StGenericVertexMaker::Make: external find use " << externalFindUse << endm;

--- a/StGenericVertexMaker/StGenericVertexMaker.cxx
+++ b/StGenericVertexMaker/StGenericVertexMaker.cxx
@@ -215,7 +215,7 @@ Int_t StGenericVertexMaker::InitRun(int runnumber){
        LOG_INFO << "BeamLine Constraint: " << endm;
        LOG_INFO << "x(z) = " << x0 << " + " << dxdz << " * z" << endm;
        LOG_INFO << "y(z) = " << y0 << " + " << dydz << " * z" << endm;
-       theFinder->UseVertexConstraint(x0,y0,dxdz,dydz,0.0001);
+
        theFinder->UseVertexConstraint(*vSeed);
 
      } else {

--- a/StGenericVertexMaker/StiPPVertex/StPPVertexFinder.cxx
+++ b/StGenericVertexMaker/StiPPVertex/StPPVertexFinder.cxx
@@ -71,7 +71,6 @@
 StPPVertexFinder::StPPVertexFinder(VertexFit_t fitMode) : StGenericVertexFinder(fitMode) {
   LOG_INFO << "StPPVertexFinder::StPPVertexFinder is in use" << endm;
 
-  mdxdz=mdydz=mX0=mY0  = 0; // beam line params
   mTotEve              = 0;
   HList=0;
   mToolkit =0;
@@ -399,18 +398,6 @@ StPPVertexFinder::CalibBeamLine(){
 //======================================================
 void 
 StPPVertexFinder::UseVertexConstraint(double x0, double y0, double dxdz, double dydz, double weight) {
-  mX0 = x0;
-  mY0 = y0;
-  mdxdz = dxdz;
-  mdydz = dydz;
-
-  // weight - not used ;
-  LOG_INFO << "StPPVertexFinder::Using Constrained Vertex" << endm;
-  LOG_INFO << "x origin = " << mX0 << endm;
-  LOG_INFO << "y origin = " << mY0 << endm;
-  LOG_INFO << "slope dxdz = " << mdxdz << endm;
-  LOG_INFO << "slope dydz = " << mdydz << endm;
-
 }
 
 

--- a/StGenericVertexMaker/StiPPVertex/StPPVertexFinder.cxx
+++ b/StGenericVertexMaker/StiPPVertex/StPPVertexFinder.cxx
@@ -33,6 +33,7 @@
 #include <Sti/StiKalmanTrack.h>
 #include <Sti/StiKalmanTrackNode.h>
 #include <Sti/StiTrackContainer.h>
+#include "Sti/StiTrack.h"
 
 #include <St_db_Maker/St_db_Maker.h>
 #include <StIOMaker/StIOMaker.h> // to save  local histos 
@@ -501,8 +502,10 @@ StPPVertexFinder::fit(StEvent* event) {
 
   std::array<int, 7> ntrk{};
 
-  for (StiTrackContainer::const_iterator it=(*tracks).begin();  it!=(*tracks).end(); ++it) {
-    const StiKalmanTrack* track = static_cast<StiKalmanTrack*>(*it);
+  for (const StiTrack* stiTrack : *tracks)
+  {
+    const StiKalmanTrack* track = static_cast<const StiKalmanTrack*>(stiTrack);
+
     TrackData t;
 
     ntrk[0]++;

--- a/StGenericVertexMaker/StiPPVertex/StPPVertexFinder.cxx
+++ b/StGenericVertexMaker/StiPPVertex/StPPVertexFinder.cxx
@@ -758,10 +758,7 @@ StPPVertexFinder::findVertexZ(VertexData &V) {
   if (sigZ < 0.1) sigZ = 0.1; // tmp, make it not smaller than the bin size
 
   // take x,y from beam line equation, TMP
-  float x = mX0 + z0*mdxdz;
-  float y = mY0 + z0*mdydz;
-
-  V.r  = TVector3(x, y, z0);
+  V.r  = TVector3(beamX(z0), beamY(z0), z0);
   V.er = TVector3(0.1, 0.1, sigZ); //tmp
   V.Lmax = Lmax;
 

--- a/StGenericVertexMaker/StiPPVertex/StPPVertexFinder.cxx
+++ b/StGenericVertexMaker/StiPPVertex/StPPVertexFinder.cxx
@@ -496,14 +496,12 @@ StPPVertexFinder::fit(StEvent* event) {
   hA[0]->Fill(4);
   
   //select reasonable tracks and add them to my list
-  int k=0;
   int kBtof=0,kCtb=0,kBemc=0, kEemc=0,kTpc=0;
   int nmAny=0;
 
-  int ntrk[7]; for(int i=0; i<7; i++) ntrk[i]=0;
+  std::array<int, 7> ntrk{};
 
   for (StiTrackContainer::const_iterator it=(*tracks).begin();  it!=(*tracks).end(); ++it) {
-    k++;
     const StiKalmanTrack* track = static_cast<StiKalmanTrack*>(*it);
     TrackData t;
 
@@ -517,7 +515,7 @@ StPPVertexFinder::fit(StEvent* event) {
     if(!matchTrack2Membrane(track,t)) {ntrk[5]++; continue;}  // kill if nFitP too small	   
     ntrk[6]++;
 
-    //cout <<"\n#e itr="<<k<<" gPt="<<track->getPt()<<" gEta="<<track->getPseudoRapidity()<<" nFitP="<<track->getFitPointCount()<<" of "<<track->getMaxPointCount()<<" poolSize="<< mTrackData->size()<<"  myW="<<t.weight<<endl;
+    //cout <<"\n#e gPt="<<track->getPt()<<" gEta="<<track->getPseudoRapidity()<<" nFitP="<<track->getFitPointCount()<<" of "<<track->getMaxPointCount()<<" poolSize="<< mTrackData->size()<<"  myW="<<t.weight<<endl;
     //printf(" t.weight AA=%f\n", t.weight);
 
     hA[1]->Fill(track->getChi2());

--- a/StGenericVertexMaker/StiPPVertex/StPPVertexFinder.cxx
+++ b/StGenericVertexMaker/StiPPVertex/StPPVertexFinder.cxx
@@ -504,35 +504,39 @@ StPPVertexFinder::fit(StEvent* event) {
 
   for (const StiTrack* stiTrack : *tracks)
   {
-    const StiKalmanTrack* track = static_cast<const StiKalmanTrack*>(stiTrack);
+    const StiKalmanTrack* stiKalmanTrack = static_cast<const StiKalmanTrack*>(stiTrack);
 
     TrackData t;
 
     ntrk[0]++;
-    if(track->getFlag()!=true)        {ntrk[1]++; continue;}
-    if(track->getPt()<mMinTrkPt)      {ntrk[2]++; continue;}
-    if(mDropPostCrossingTrack){
-      if(isPostCrossingTrack(track))  {ntrk[3]++; continue;}  // kill if it has hits in wrong z
-    }
-    if(!examinTrackDca(track,t))      {ntrk[4]++; continue;}  // drop from DCA		   
-    if(!matchTrack2Membrane(track,t)) {ntrk[5]++; continue;}  // kill if nFitP too small	   
+
+    if(stiKalmanTrack->getFlag() != true)        {ntrk[1]++; continue;}
+    if(stiKalmanTrack->getPt() < mMinTrkPt)      {ntrk[2]++; continue;}
+    if(mDropPostCrossingTrack &&
+       isPostCrossingTrack(stiKalmanTrack))      {ntrk[3]++; continue;}  // kill if it has hits in wrong z
+    if(!examinTrackDca(stiKalmanTrack, t))       {ntrk[4]++; continue;}  // drop from DCA
+    if(!matchTrack2Membrane(stiKalmanTrack, t))  {ntrk[5]++; continue;}  // kill if nFitP too small
+
     ntrk[6]++;
 
-    //cout <<"\n#e gPt="<<track->getPt()<<" gEta="<<track->getPseudoRapidity()<<" nFitP="<<track->getFitPointCount()<<" of "<<track->getMaxPointCount()<<" poolSize="<< mTrackData->size()<<"  myW="<<t.weight<<endl;
+    //cout << "\n#e gPt="<<stiKalmanTrack->getPt()
+    //     << " gEta="<<stiKalmanTrack->getPseudoRapidity()
+    //     << " nFitP="<<stiKalmanTrack->getFitPointCount() << " of " << stiKalmanTrack->getMaxPointCount()
+    //     << " poolSize="<< mTrackData->size() << "  myW=" << t.weight << endl;
     //printf(" t.weight AA=%f\n", t.weight);
 
-    hA[1]->Fill(track->getChi2());
-    hA[2]->Fill(track->getFitPointCount());
-    hA[16]->Fill(track->getPt());
-    //  dumpKalmanNodes(track);
+    hA[1]->Fill(stiKalmanTrack->getChi2());
+    hA[2]->Fill(stiKalmanTrack->getFitPointCount());
+    hA[16]->Fill(stiKalmanTrack->getPt());
+    //  dumpKalmanNodes(stiKalmanTrack);
     
     // ......... matcho various detectors ....................
-    if(mUseBtof) matchTrack2BTOF(track,t,btofGeom);  // matching track to btofGeometry
-    if(mUseCtb)  matchTrack2CTB(track,t);
-    matchTrack2BEMC(track,t,242); // middle of tower in Rxy
-    matchTrack2EEMC(track,t,288); // middle of tower in Z
+    if(mUseBtof) matchTrack2BTOF(stiKalmanTrack, t, btofGeom);  // matching track to btofGeometry
+    if(mUseCtb)  matchTrack2CTB(stiKalmanTrack, t);
+    matchTrack2BEMC(stiKalmanTrack, t, 242); // middle of tower in Rxy
+    matchTrack2EEMC(stiKalmanTrack, t, 288); // middle of tower in Z
     //.... all test done on this track .........
-    t.mother=track;
+    t.mother = stiKalmanTrack;
     mTrackData.push_back(t); 
 
     hA[5]->Fill(t.rxyDca);
@@ -549,13 +553,13 @@ StPPVertexFinder::fit(StEvent* event) {
     //  t.print();
   }
 
-  LOG_INFO<< Form("PPV:: # of input track          = %d",ntrk[0])<<endm;
-  LOG_INFO<< Form("PPV:: dropped due to flag       = %d",ntrk[1])<<endm;
-  LOG_INFO<< Form("PPV:: dropped due to pt         = %d",ntrk[2])<<endm;
-  LOG_INFO<< Form("PPV:: dropped due to PCT check  = %d",ntrk[3])<<endm;
-  LOG_INFO<< Form("PPV:: dropped due to DCA check  = %d",ntrk[4])<<endm;
-  LOG_INFO<< Form("PPV:: dropped due to NHit check = %d",ntrk[5])<<endm;
-  LOG_INFO<< Form("PPV:: # of track after all cuts = %d",ntrk[6])<<endm;
+  LOG_INFO << Form("PPV:: # of input track          = %d\n", ntrk[0])
+           << Form("PPV:: dropped due to flag       = %d\n", ntrk[1])
+           << Form("PPV:: dropped due to pt         = %d\n", ntrk[2])
+           << Form("PPV:: dropped due to PCT check  = %d\n", ntrk[3])
+           << Form("PPV:: dropped due to DCA check  = %d\n", ntrk[4])
+           << Form("PPV:: dropped due to NHit check = %d\n", ntrk[5])
+           << Form("PPV:: # of track after all cuts = %d",   ntrk[6]) << endm;
 
   if(mUseCtb) {
     ctbList ->print();
@@ -574,14 +578,17 @@ StPPVertexFinder::fit(StEvent* event) {
   bemcList->doHisto();
   eemcList->doHisto();
 
-  LOG_INFO << "PPV::fit() nEve="<<mTotEve<<" , "<<nmAny<<" traks with good DCA, matching: BTOF="<<kBtof<<" CTB="<<kCtb<<" BEMC="<<kBemc<<" EEMC="<<kEemc<<endm;
+  LOG_INFO << "PPV::fit() nEve=" << mTotEve << " , "
+           << nmAny << " traks with good DCA, matching: BTOF="
+           << kBtof << " CTB=" << kCtb << " BEMC=" << kBemc << " EEMC=" << kEemc << endm;
 
 
-  if(nmAny<mMinMatchTr &&  mStoreUnqualifiedVertex<=0){
-    LOG_INFO << "StPPVertexFinder::fit() nEve="<<mTotEve<<" Quit, to few matched tracks"<<endm;
+  if(nmAny < mMinMatchTr && mStoreUnqualifiedVertex <= 0) {
+    LOG_INFO << "StPPVertexFinder::fit() nEve=" << mTotEve << " Quit, to few matched tracks" << endm;
     printInfo();
     return 0;
   }
+
   hA[0]->Fill(5);
 
   if(kBemc)  hA[0]->Fill(6);
@@ -598,10 +605,10 @@ StPPVertexFinder::fit(StEvent* event) {
   while(1) {
     if(! buildLikelihoodZ() ) break;
     VertexData V;
-    V.id=++vertexID;
+    V.id = ++vertexID;
     if(! findVertexZ(V)) break;
   
-    bool trigV=evalVertexZ(V);   // V.print();
+    bool trigV = evalVertexZ(V);   // V.print();
     //bump up rank of 2+ track all vertices 
     if(V.nAnyMatch>=mMinMatchTr) V.Lmax+=par_rankOffset;
     if(!trigV) {
@@ -616,9 +623,9 @@ StPPVertexFinder::fit(StEvent* event) {
     
     {// ... more rank QA ...
       float rank=V.Lmax;
-      if(rank>1e6)  hA[17]->Fill(log(rank-1e6)+10);
-      else if(rank>0)   hA[17]->Fill(log(rank));
-      else   hA[17]->Fill(log(rank+1e6)-10);
+      if(rank>1e6)     hA[17]->Fill(log(rank-1e6)+10);
+      else if(rank>0)  hA[17]->Fill(log(rank));
+      else             hA[17]->Fill(log(rank+1e6)-10);
     }
 
     if (mVertexFitMode == VertexFit_t::Beamline3D) {
@@ -672,28 +679,28 @@ StPPVertexFinder::buildLikelihoodZ(){
   double *Ma=hM->GetArray(); // track multiplicity  histogram 
   double *Wa=hW->GetArray(); // track weight histogram 
   
+  // Loop over pre-selected tracks only
   for (const TrackData &t : mTrackData) {
     if(t.vertexID!=0) continue; // track already used
     if(t.anyMatch) n1++;
     //  t.print();
-    float z0=t.zDca;
-    float ez=t.ezDca;
-    float ez2=ez*ez;
-    int j1=hL->FindBin(z0-mMaxZradius-.1);
-    int j2=hL->FindBin(z0+mMaxZradius+.1);
-    float base=dzMax2/2/ez2;
-    float totW=t.weight;
+    float z0   = t.zDca;  // z coordinate at DCA
+    float ez   = t.ezDca; // error on z coordinate at DCA
+    float ez2  = ez*ez;
+    int   j1   = hL->FindBin(z0-mMaxZradius-.1);
+    int   j2   = hL->FindBin(z0+mMaxZradius+.1);
+    float base = dzMax2/2/ez2;
+    float totW = t.weight;
     //  printf("Z0=%f ez=%f j1=%d j2=%d base=%f gPt/GeV=%.3f ctbW=%.3f\n",z0,ez,j1,j2,base,t.gPt,ctbW);
 
-    int j;
-    for(j=j1;j<=j2;j++) {
-      float z=hL->GetBinCenter(j);
-      float dz=z-z0;
-      float xx=base-dz*dz/2/ez2;
+    for (int j=j1; j<=j2; j++) {
+      float z  = hL->GetBinCenter(j);
+      float dz = z-z0;
+      float xx = base - dz*dz/2/ez2;
       if(xx<=0) continue;
-      La[j]+=xx*totW;
-      Ma[j]+=1.;
-      Wa[j]+=totW;
+      La[j] += xx*totW;
+      Ma[j] += 1.;
+      Wa[j] += totW;
       // printf("z=%f dz=%f  xx=%f\n",z,dz,xx);
     }
     // break; // tmp , to get only one track
@@ -711,50 +718,52 @@ StPPVertexFinder::findVertexZ(VertexData &V) {
 
   if(hL->GetMaximum()<=0) return false; // no more tracks left
 
-  int iMax=hL-> GetMaximumBin();
-  float z0=hL-> GetBinCenter(iMax);
-  float Lmax=hL-> GetBinContent(iMax);
-  float accM=hM-> GetBinContent(iMax);
-  float accW=hW-> GetBinContent(iMax);
+  int   iMax = hL->GetMaximumBin();
+  float z0   = hL->GetBinCenter(iMax);
+  float Lmax = hL->GetBinContent(iMax);
+  float accM = hM->GetBinContent(iMax);
+  float accW = hW->GetBinContent(iMax);
   assert(accM>0);
-  float avrW=accW/accM;
+  float avrW = accW/accM;
 
   // search for sigma of the vertex
-  float Llow=0.9* Lmax;
-  if((Lmax-Llow)<8*avrW )  Llow=Lmax-8*avrW;  // to be at least 4 sigma
-  int i;
-  double *L=hL->GetArray(); // likelyhood 
+  float Llow = 0.9* Lmax;
+  if ((Lmax-Llow) < 8*avrW )  Llow = Lmax - 8*avrW;  // to be at least 4 sigma
 
-  int iLow=-1, iHigh=-1;
-  for(i=iMax;i<=hL->GetNbinsX();i++) {
-    if(L[i] >Llow) continue;
-    iHigh=i;
+  double *L = hL->GetArray(); // likelyhood 
+
+  int iLow = -1, iHigh = -1;
+  for(int i=iMax; i<=hL->GetNbinsX(); i++) {
+    if(L[i] > Llow) continue;
+    iHigh = i;
     break;
   }
-  for(i=iMax;i>=1;i--) {
-    if(L[i] >Llow) continue;
-    iLow=i;
+  for(int i=iMax; i>=1; i--) {
+    if(L[i] > Llow) continue;
+    iLow = i;
     break;
   }
   
-  float zLow=hL-> GetBinCenter(iLow);
-  float zHigh=hL-> GetBinCenter(iHigh);
+  float zLow  = hL->GetBinCenter(iLow);
+  float zHigh = hL->GetBinCenter(iHigh);
 
-  float kSig= sqrt(2*(Lmax-Llow)/avrW);
-  float sigZ= (zHigh-zLow)/2/kSig;
-  LOG_DEBUG<< Form("PPV:: iLow/iMax/iHigh=%d/%d/%d\n",iLow,iMax,iHigh)
-	  <<Form(" accM=%f  accW=%f  avrW=%f\n",accM,accW,avrW)   
-	  <<Form("  Z low/max/high=%f %f %f, kSig=%f, sig=%f\n",zLow,z0,zHigh,kSig,sigZ)
-	  <<Form(" found  PPVertex(ID=%d,neve=%d) z0 =%.2f +/- %.2f\n",V.id,mTotEve,z0,sigZ)<<endm;
-  if(sigZ<0.1) sigZ=0.1; // tmp, make it not smaller than the bin size
+  float kSig = sqrt(2*(Lmax-Llow)/avrW);
+  float sigZ = (zHigh-zLow)/2/kSig;
+
+  LOG_DEBUG << Form("PPV:: iLow/iMax/iHigh=%d/%d/%d\n",iLow,iMax,iHigh)
+            << Form(" accM=%f  accW=%f  avrW=%f\n",accM,accW,avrW)   
+            << Form("  Z low/max/high=%f %f %f, kSig=%f, sig=%f\n",zLow,z0,zHigh,kSig,sigZ)
+            << Form(" found  PPVertex(ID=%d,neve=%d) z0 =%.2f +/- %.2f\n",V.id,mTotEve,z0,sigZ)<<endm;
+
+  if (sigZ < 0.1) sigZ = 0.1; // tmp, make it not smaller than the bin size
 
   // take x,y from beam line equation, TMP
-  float x=mX0+z0*mdxdz;
-  float y=mY0+z0*mdydz;
+  float x = mX0 + z0*mdxdz;
+  float y = mY0 + z0*mdydz;
 
-  V.r=TVector3(x,y,z0);
-  V.er=TVector3(0.1,0.1,sigZ); //tmp
-  V.Lmax=Lmax;
+  V.r  = TVector3(x, y, z0);
+  V.er = TVector3(0.1, 0.1, sigZ); //tmp
+  V.Lmax = Lmax;
 
   return true;
 }
@@ -770,12 +779,17 @@ StPPVertexFinder::evalVertexZ(VertexData &V) { // and tag used tracks
   
   for (TrackData &t : mTrackData)
   {
-    if(t.vertexID!=0) continue;
-    if(! t.matchVertex(V,mMaxZradius)) continue; // track to far
-    // this track belongs to this vertex
+    // Skip tracks already matched to a vertex
+    if(t.vertexID != 0) continue;
+
+    // Do not match tracks to vertex V if they are too far in Z
+    // (i.e. |delta_z| > (mMaxZradius + sigma_z))
+    if(! t.matchVertex(V, mMaxZradius)) continue;
+
+    // Otherwise, this track belongs to this vertex
     n1++;
-    t.vertexID=V.id;
-    V.gPtSum+=t.gPt;
+    t.vertexID  = V.id;
+    V.gPtSum   += t.gPt;
     if(mBeamLineTracks) vertex3D->addTrack(&t);
     if( t.gPt>mCut_oneTrackPT && ( t.mBemc>0|| t.mEemc>0) ) nHiPt++;
 
@@ -797,14 +811,16 @@ StPPVertexFinder::evalVertexZ(VertexData &V) { // and tag used tracks
     if( t.anyMatch)     V.nAnyMatch++;
     else if (t.anyVeto) V.nAnyVeto++;
   } 
-  V.nUsedTrack=n1;  
 
-  bool validVertex = V.nAnyMatch>=mMinMatchTr;
-  if((mAlgoSwitches & kSwitchOneHighPT) && ( nHiPt>0)) {
-    validVertex|=1;
+  V.nUsedTrack = n1;  
+
+  bool validVertex = (V.nAnyMatch >= mMinMatchTr);
+
+  if ((mAlgoSwitches & kSwitchOneHighPT) && ( nHiPt>0)) {
+    validVertex |= 1;
   }
 
-  if(!validVertex) { // discrad vertex
+  if (!validVertex) { // discrad vertex
     //no match tracks in this vertex, tag vertex ID in tracks differently
     //V.print(cout);
     LOG_DEBUG << "StPPVertexFinder::evalVertex Vid="<<V.id<<" rejected"<<endm;
@@ -1083,7 +1099,7 @@ StPPVertexFinder::dumpKalmanNodes(const StiKalmanTrack*track){
 //==========================================================
 //==========================================================
 bool  
-StPPVertexFinder::examinTrackDca(const StiKalmanTrack*track,TrackData &t){
+StPPVertexFinder::examinTrackDca(const StiKalmanTrack* track, TrackData &t){
 
   //1 StiKalmanTrackNode* inNode=track->getInnerMostNode();
   //1 cout <<"#e  track->getPseudoRapidity()="<<track->getPseudoRapidity()<<" track->getFitPointCount()="<<track->getFitPointCount()<<endl;
@@ -1104,21 +1120,21 @@ StPPVertexFinder::examinTrackDca(const StiKalmanTrack*track,TrackData &t){
  
   //1 cout<<"#e inBeam |P|="<<bmNode->getP()<<" pT="<<bmNode->getPt()<<" local x="<<xL(bmNode)<<" y="<<yL(bmNode)<<" +/- "<<eyL(bmNode)<<" z="<<zL(bmNode)<<" +/- "<<ezL(bmNode)<<endl;
 
-  t.zDca=zL(bmNode);
-  t.ezDca=ezL(bmNode);
-  t.rxyDca=rxy;
-  t.gPt=bmNode->getPt();
+  t.zDca   = zL(bmNode);
+  t.ezDca  = ezL(bmNode);
+  t.rxyDca = rxy;
+  t.gPt    = bmNode->getPt();
 
   //...... record more detals for 3D vertex reco
   t.dcaTrack.R.SetXYZ(xG(bmNode),yG(bmNode),zG(bmNode));
   // approximation below: use sigX=sigY, I do not want to deal wih rotations in X-Y plane, Jan B.
-  t.dcaTrack.sigYloc=eyL(bmNode); 
-  t.dcaTrack.sigZ=ezL(bmNode); 
-  StThreeVectorF const globP3=bmNode->getGlobalMomentumF();
+  t.dcaTrack.sigYloc = eyL(bmNode);
+  t.dcaTrack.sigZ    = ezL(bmNode);
+  StThreeVectorF const globP3 = bmNode->getGlobalMomentumF();
   t.dcaTrack.gP.SetXYZ(globP3.x(),globP3.y(),globP3.z());
-  t.dcaTrack.fitErr=bmNode->fitErrs();
-  t.dcaTrack.gChi2=track1.getChi2();
-  t.dcaTrack.nFitPoint=track1.getFitPointCount();
+  t.dcaTrack.fitErr    = bmNode->fitErrs();
+  t.dcaTrack.gChi2     = track1.getChi2();
+  t.dcaTrack.nFitPoint = track1.getFitPointCount();
   //  t.dcaTrack.print();
 
   return true;
@@ -1260,7 +1276,6 @@ StPPVertexFinder::matchTrack2BEMC(const StiKalmanTrack* track,TrackData &t, floa
   
   StiKalmanTrackNode* ouNode=track->getOuterMostNode();
 
-  StThreeVectorD posCyl;
   float path=-1;
   //alternative helix extrapolation:
   StThreeVectorD ou(ouNode->getX(),ouNode->getY(),ouNode->getZ());
@@ -1278,7 +1293,8 @@ StPPVertexFinder::matchTrack2BEMC(const StiKalmanTrack* track,TrackData &t, floa
       Form(" d2.firts=%f, second=%f, try first\n", d2.first, d2.second)<<endm;
     path=d2.first;
   }
-  posCyl = hlx.at(path);
+
+  StThreeVectorD posCyl = hlx.at(path);
   // printf(" punch Cylinder x,y,z=%.1f, %.1f, %.1f path.second=%.1f\n",posCyl.x(),posCyl.y(),posCyl.z(),path);
 
 

--- a/StGenericVertexMaker/StiPPVertex/StPPVertexFinder.cxx
+++ b/StGenericVertexMaker/StiPPVertex/StPPVertexFinder.cxx
@@ -394,12 +394,6 @@ StPPVertexFinder::CalibBeamLine(){
   mBeamLineTracks=1; 
 }
 
-//======================================================
-//======================================================
-void 
-StPPVertexFinder::UseVertexConstraint(double x0, double y0, double dxdz, double dydz, double weight) {
-}
-
 
 //==========================================================
 //==========================================================

--- a/StGenericVertexMaker/StiPPVertex/StPPVertexFinder.h
+++ b/StGenericVertexMaker/StiPPVertex/StPPVertexFinder.h
@@ -83,12 +83,6 @@ class StPPVertexFinder: public StGenericVertexFinder {
   int    mBeamLineTracks; // activates writing them out + lot of QA histos, 
                           // use  BFC option: VtxSeedCalG to enable it, expert only
 
-  // beam line
-  double          mX0  ;     // starting point of beam parameterization
-  double          mY0  ;     // starting point of beam parameterization
-  double          mdxdz;     // beam slope
-  double          mdydz;     // beam slope
-
   // util
   StiToolkit     *mToolkit;
   BtofHitList    *btofList;  // dongx

--- a/StGenericVertexMaker/StiPPVertex/StPPVertexFinder.h
+++ b/StGenericVertexMaker/StiPPVertex/StPPVertexFinder.h
@@ -48,6 +48,8 @@ class StPPVertexFinder: public StGenericVertexFinder {
   void matchTrack2BEMC(const StiKalmanTrack*, TrackData &t, float rxy);
   bool matchTrack2Membrane(const StiKalmanTrack*, TrackData &t);
   bool isPostCrossingTrack(const StiKalmanTrack* track);
+
+  /// A container with pre-selected tracks to be used in seed finding
   vector<TrackData>  mTrackData;
   vector<VertexData> mVertexData;
   Vertex3D *vertex3D; // for stand alone 3D vertex reco

--- a/StGenericVertexMaker/StiPPVertex/StPPVertexFinder.h
+++ b/StGenericVertexMaker/StiPPVertex/StPPVertexFinder.h
@@ -98,7 +98,7 @@ class StPPVertexFinder: public StGenericVertexFinder {
   //  void plotTracksDca();
   void initHisto();
 
-  virtual void  UseVertexConstraint(double x0, double y0, double dxdz, double dydz, double weight);
+  virtual void  UseVertexConstraint() {}
   
 public:
   void UsePCT(bool x=true)			{setDropPostCrossingTrack(!x);}

--- a/StGenericVertexMaker/StiPPVertex/StPPVertexFinder.h
+++ b/StGenericVertexMaker/StiPPVertex/StPPVertexFinder.h
@@ -97,6 +97,8 @@ class StPPVertexFinder: public StGenericVertexFinder {
   //  void plotVertex(VertexData *);
   //  void plotTracksDca();
   void initHisto();
+
+  virtual void  UseVertexConstraint(double x0, double y0, double dxdz, double dydz, double weight);
   
 public:
   void UsePCT(bool x=true)			{setDropPostCrossingTrack(!x);}
@@ -114,7 +116,6 @@ public:
   virtual  ~StPPVertexFinder();
   int       fit(StEvent*);        
   void      printInfo(ostream& = cout) const;
-  void      UseVertexConstraint(double x0, double y0, double dxdz, double dydz, double weight);
  
   // over-written method
   virtual void  Init();

--- a/StGenericVertexMaker/StiPPVertex/TrackData.cxx
+++ b/StGenericVertexMaker/StiPPVertex/TrackData.cxx
@@ -26,9 +26,12 @@ TrackData::TrackData() {
 bool 
 TrackData::matchVertex(VertexData &V, float dzMax) {
 
-  float dz=zDca-V.r.z();
-  bool ret= fabs(dz) < dzMax+ezDca;
-  if(ret)   LOG_DEBUG<< Form("PPV::matchTr2Ver VerID=%d  weight=%.2f anyM=%d anyV=%d  m: ctb=%d  bemc=%d eemc=%d tpc=%d dz=%.2f +/- %.2f\n",V.id,weight,anyMatch,anyVeto,mCtb,mBemc,mEemc,mTpc,dz,ezDca)<<endm;
+  float dz = zDca - V.r.z();
+  bool ret = fabs(dz) < dzMax + ezDca;
+
+  if (ret)
+     LOG_DEBUG<< Form("PPV::matchTr2Ver VerID=%d  weight=%.2f anyM=%d anyV=%d  m: ctb=%d  bemc=%d eemc=%d tpc=%d dz=%.2f +/- %.2f\n",V.id,weight,anyMatch,anyVeto,mCtb,mBemc,mEemc,mTpc,dz,ezDca)<<endm;
+
   return ret;
 }
 

--- a/StGenericVertexMaker/StppLMVVertexFinder.cxx
+++ b/StGenericVertexMaker/StppLMVVertexFinder.cxx
@@ -247,9 +247,7 @@ StppLMVVertexFinder::UseVertexConstraint(double x0, double y0,
   double mY0 = sBeamline.y0;
   double mdxdz = sBeamline.dxdz;
   double mdydz = sBeamline.dydz;
-  mWeight = weight;
   LOG_INFO << "StppLMVVertexFinder::Using Constrained Vertex" << endm;
-  LOG_INFO << "NOT used (JB) weight in fit = " << weight <<  endm;
   StThreeVectorD origin(mX0,mY0,0.0);
   double pt  = 88889999;   
   double nxy=::sqrt(mdxdz*mdxdz +  mdydz*mdydz);

--- a/StGenericVertexMaker/StppLMVVertexFinder.cxx
+++ b/StGenericVertexMaker/StppLMVVertexFinder.cxx
@@ -240,8 +240,7 @@ StppLMVVertexFinder::printInfo(ostream& os) const
 //======================================================
 //======================================================
 void 
-StppLMVVertexFinder::UseVertexConstraint(double x0, double y0, 
-					 double dxdz, double dydz, double weight) {
+StppLMVVertexFinder::UseVertexConstraint() {
   mVertexConstrain = true;
   double mX0 = sBeamline.x0;
   double mY0 = sBeamline.y0;

--- a/StGenericVertexMaker/StppLMVVertexFinder.cxx
+++ b/StGenericVertexMaker/StppLMVVertexFinder.cxx
@@ -30,7 +30,6 @@ StppLMVVertexFinder::StppLMVVertexFinder() {
   mBeamHelix           = 0;
   mVertexConstrain     = false;
   mTotEve              = 0;
-  mdxdz=mdydz=mX0=mY0  = 0;
   mMode                = 1;
 }
 
@@ -244,16 +243,12 @@ void
 StppLMVVertexFinder::UseVertexConstraint(double x0, double y0, 
 					 double dxdz, double dydz, double weight) {
   mVertexConstrain = true;
-  mX0 = x0;
-  mY0 = y0;
-  mdxdz = dxdz;
-  mdydz = dydz;
+  double mX0 = sBeamline.x0;
+  double mY0 = sBeamline.y0;
+  double mdxdz = sBeamline.dxdz;
+  double mdydz = sBeamline.dydz;
   mWeight = weight;
   LOG_INFO << "StppLMVVertexFinder::Using Constrained Vertex" << endm;
-  LOG_INFO << "x origin = " << mX0 << endm;
-  LOG_INFO << "y origin = " << mY0 << endm;
-  LOG_INFO << "slope dxdz = " << mdxdz << endm;
-  LOG_INFO << "slope dydz = " << mdydz << endm;
   LOG_INFO << "NOT used (JB) weight in fit = " << weight <<  endm;
   StThreeVectorD origin(mX0,mY0,0.0);
   double pt  = 88889999;   
@@ -305,7 +300,7 @@ StppLMVVertexFinder::matchTrack2CTB (StTrack* track, float & sigma) {
   StPhysicalHelixD TrkHlxIn=track->geometry()->helix();
 
   //           check Rxy_min condition  close to beam    
-  double spath = TrkHlxIn.pathLength(mX0, mY0 );
+  double spath = TrkHlxIn.pathLength(sBeamline.x0, sBeamline.y0);
   StThreeVectorD posDCA = TrkHlxIn.at(spath);
   //  cout<<" DCA Position: "<<posDCA<<endl;
   double x_m = posDCA.x(), y_m = posDCA.y();
@@ -418,8 +413,8 @@ StppLMVVertexFinder::ppLMV5() {
   //printf("passed %d tracks match to CTB,  BeamLine=%d\n",totTr,mVertexConstrain );
   LOG_DEBUG << "passed " << totTr << " tracks match to CTB,  BeamLine=" << mVertexConstrain << endm;
    
-  double xo = mX0;
-  double yo = mY0;
+  double xo = sBeamline.x0;
+  double yo = sBeamline.y0;
  
   //Do the actual vertex fitting, continue until good
   double A11=0.0,A12=0.0,A13=0.0;

--- a/StGenericVertexMaker/StppLMVVertexFinder.h
+++ b/StGenericVertexMaker/StppLMVVertexFinder.h
@@ -37,7 +37,6 @@ class StppLMVVertexFinder: public StGenericVertexFinder , StCtbUtility {
  private:
   
     unsigned int           mMinNumberOfFitPointsOnTrack;
-    double                 mWeight ;          // Weight in fit for vertex contraint
     StPhysicalHelixD*      mBeamHelix;        // Beam Line helix
 
     //jan--------------------

--- a/StGenericVertexMaker/StppLMVVertexFinder.h
+++ b/StGenericVertexMaker/StppLMVVertexFinder.h
@@ -35,7 +35,7 @@ class StppLMVVertexFinder: public StGenericVertexFinder , StCtbUtility {
 
  private:
 
-    virtual void    UseVertexConstraint(double x0, double y0, double dxdz, double dydz, double weight);
+    virtual void    UseVertexConstraint();
   
     unsigned int           mMinNumberOfFitPointsOnTrack;
     StPhysicalHelixD*      mBeamHelix;        // Beam Line helix

--- a/StGenericVertexMaker/StppLMVVertexFinder.h
+++ b/StGenericVertexMaker/StppLMVVertexFinder.h
@@ -27,7 +27,6 @@ class StppLMVVertexFinder: public StGenericVertexFinder , StCtbUtility {
     virtual         ~StppLMVVertexFinder();
     int             fit(StEvent*);         
     void            printInfo(ostream& = cout) const;
-    void            UseVertexConstraint(double x0, double y0, double dxdz, double dydz, double weight);
     void            Clear();
 
     // over-written method
@@ -35,6 +34,8 @@ class StppLMVVertexFinder: public StGenericVertexFinder , StCtbUtility {
     void addFakeVerex(float z);
 
  private:
+
+    virtual void    UseVertexConstraint(double x0, double y0, double dxdz, double dydz, double weight);
   
     unsigned int           mMinNumberOfFitPointsOnTrack;
     StPhysicalHelixD*      mBeamHelix;        // Beam Line helix

--- a/StGenericVertexMaker/StppLMVVertexFinder.h
+++ b/StGenericVertexMaker/StppLMVVertexFinder.h
@@ -36,10 +36,6 @@ class StppLMVVertexFinder: public StGenericVertexFinder , StCtbUtility {
 
  private:
   
-    double          mX0  ;     // starting point of beam parameterization
-    double          mY0  ;     // starting point of beam parameterization
-    double          mdxdz;     // beam slope
-    double          mdydz;     // beam slope
     unsigned int           mMinNumberOfFitPointsOnTrack;
     double                 mWeight ;          // Weight in fit for vertex contraint
     StPhysicalHelixD*      mBeamHelix;        // Beam Line helix

--- a/StGenericVertexMaker/StvPPVertex/StPPVertexFinder.cxx
+++ b/StGenericVertexMaker/StvPPVertex/StPPVertexFinder.cxx
@@ -79,7 +79,6 @@ StPPVertexFinder::StPPVertexFinder()
 {
   LOG_INFO << "StPPVertexFinder::StPPVertexFinder is in use" << endm;
 
-  mdxdz=mdydz=mX0=mY0  = 0; // beam line params
   mTotEve              = 0;
   HList=0;
   mToolkit =0;
@@ -409,19 +408,6 @@ void StPPVertexFinder::CalibBeamLine()
 //======================================================
 //======================================================
 void StPPVertexFinder::UseVertexConstraint(double x0, double y0, double dxdz, double dydz, double weight) {
-  mVertexConstrain = true;
-  mX0 = x0;
-  mY0 = y0;
-  mdxdz = dxdz;
-  mdydz = dydz;
-
-  // weight - not used ;
-  LOG_INFO << "StPPVertexFinder::Using Constrained Vertex" << endm;
-  LOG_INFO << "x origin = " << mX0 << endm;
-  LOG_INFO << "y origin = " << mY0 << endm;
-  LOG_INFO << "slope dxdz = " << mdxdz << endm;
-  LOG_INFO << "slope dydz = " << mdydz << endm;
-
 }
 
 

--- a/StGenericVertexMaker/StvPPVertex/StPPVertexFinder.cxx
+++ b/StGenericVertexMaker/StvPPVertex/StPPVertexFinder.cxx
@@ -405,11 +405,6 @@ void StPPVertexFinder::CalibBeamLine()
   mBeamLineTracks=1; 
 }
 
-//======================================================
-//======================================================
-void StPPVertexFinder::UseVertexConstraint(double x0, double y0, double dxdz, double dydz, double weight) {
-}
-
 
 //==========================================================
 //==========================================================

--- a/StGenericVertexMaker/StvPPVertex/StPPVertexFinder.cxx
+++ b/StGenericVertexMaker/StvPPVertex/StPPVertexFinder.cxx
@@ -760,10 +760,7 @@ bool StPPVertexFinder::findVertexZ(VertexData &V) {
   if(sigZ<0.1) sigZ=0.1; // tmp, make it not smaller than the bin size
 
   // take x,y from beam line equation, TMP
-  float x=mX0+z0*mdxdz;
-  float y=mY0+z0*mdydz;
-
-  V.r=TVector3(x,y,z0);
+  V.r=TVector3(beamX(z0), beamY(z0), z0);
   V.er=TVector3(0.1,0.1,sigZ); //tmp
   V.Lmax=Lmax;
 

--- a/StGenericVertexMaker/StvPPVertex/StPPVertexFinder.h
+++ b/StGenericVertexMaker/StvPPVertex/StPPVertexFinder.h
@@ -86,6 +86,8 @@ class StPPVertexFinder: public StGenericVertexFinder {
   //  void plotVertex(VertexData *);
   //  void plotTracksDca();
   void initHisto();
+
+  virtual void  UseVertexConstraint(double x0, double y0, double dxdz, double dydz, double weight);
   
 public:
   void UsePCT(bool x=true)			{setDropPostCrossingTrack(!x);}
@@ -103,7 +105,6 @@ public:
   virtual  ~StPPVertexFinder();
   int       fit(StEvent*);        
   void      printInfo(ostream& = cout) const;
-  void      UseVertexConstraint(double x0, double y0, double dxdz, double dydz, double weight);
  
   // over-written method
   virtual void  Init();

--- a/StGenericVertexMaker/StvPPVertex/StPPVertexFinder.h
+++ b/StGenericVertexMaker/StvPPVertex/StPPVertexFinder.h
@@ -73,12 +73,6 @@ class StPPVertexFinder: public StGenericVertexFinder {
   int    mBeamLineTracks; // activates writing them out + lot of QA histos, 
                           // use  BFC option: VtxSeedCalG to enable it, expert only
 
-  // beam line
-  double          mX0  ;     // starting point of beam parameterization
-  double          mY0  ;     // starting point of beam parameterization
-  double          mdxdz;     // beam slope
-  double          mdydz;     // beam slope
-
   // util
   BtofHitList    *btofList;  // dongx
   CtbHitList     *ctbList;

--- a/StGenericVertexMaker/StvPPVertex/StPPVertexFinder.h
+++ b/StGenericVertexMaker/StvPPVertex/StPPVertexFinder.h
@@ -87,7 +87,7 @@ class StPPVertexFinder: public StGenericVertexFinder {
   //  void plotTracksDca();
   void initHisto();
 
-  virtual void  UseVertexConstraint(double x0, double y0, double dxdz, double dydz, double weight);
+  virtual void  UseVertexConstraint() {}
   
 public:
   void UsePCT(bool x=true)			{setDropPostCrossingTrack(!x);}


### PR DESCRIPTION
These changes have been tested on a 10k W embedding sample. The following pairs of reconstruction options returned identical results:

```
PPV beamline
PPV beamline3D
VFMinuit beamline
VFMinuit beamline3D
```
