### PR TITLE
Removed special treatment for MC data in PPV vertex finder

### DIFF
--- a/StGenericVertexMaker/StGenericVertexFinder.cxx
+++ b/StGenericVertexMaker/StGenericVertexFinder.cxx
@@ -38,7 +38,6 @@ StGenericVertexFinder::StGenericVertexFinder(VertexFit_t fitMode) :
   mMode(0),
   mVertexFitMode(fitMode),
   mDebugLevel(0),
-  mIsMC(false),
   mUseBtof(false),
   mUseCtb(false)
 {

--- a/StGenericVertexMaker/StGenericVertexFinder.h
+++ b/StGenericVertexMaker/StGenericVertexFinder.h
@@ -46,7 +46,6 @@ public:
   virtual void           UsePCT(bool usePCT = true);
   virtual void           UseBTOF(bool useBTOF = true){mUseBtof=useBTOF;}
   virtual void           UseCTB (bool useCTB  = true){mUseCtb =useCTB ;}
-          void           setMC  (bool x=true)        {mIsMC   = x     ;}
   virtual void           CalibBeamLine(){ /* noop */;} // overload if useful
 
   virtual void           printInfo(ostream& = cout) const=0;
@@ -77,7 +76,6 @@ protected:
   VertexFit_t            mVertexFitMode;
 
   int                    mDebugLevel;
-  bool                   mIsMC;              // flag minor differences between Data & M-C
   bool                   mUseBtof;           // default use btof = false
   bool                   mUseCtb;            // default use ctb = false
 

--- a/StGenericVertexMaker/StGenericVertexMaker.cxx
+++ b/StGenericVertexMaker/StGenericVertexMaker.cxx
@@ -140,9 +140,6 @@ Int_t StGenericVertexMaker::Init()
     theFinder= new StPPVertexFinder(vertexFitMode);
 
     if ( IAttr("VFPPVnoCTB")) theFinder->UseCTB(kFALSE);	
-    if(GetMaker("emcY2")) {//very dirty, but detects if it is M-C or real data
-      ((StPPVertexFinder*) theFinder)->setMC(kTRUE);
-    }
 
   } else if ( IAttr("VFPPVEv") ||  IAttr("VFPPVEvNoBTof")
            ||(IAttr("VFPPV")   &&  IAttr("Stv"))        )  { // 2 version of PPV w/ & w/o Btof

--- a/StGenericVertexMaker/StiPPVertex/StPPVertexFinder.cxx
+++ b/StGenericVertexMaker/StiPPVertex/StPPVertexFinder.cxx
@@ -75,7 +75,6 @@ StPPVertexFinder::StPPVertexFinder(VertexFit_t fitMode) : StGenericVertexFinder(
   mToolkit =0;
   memset(hA,0,sizeof(hA));
 
-  setMC(false);                      // default = real Data
   UseCTB(true);                      // default CTB is in the data stream
   setDropPostCrossingTrack(true);    // default PCT rejection on
   mVertexOrderMethod = orderByRanking; // change ordering by ranking
@@ -150,7 +149,6 @@ StPPVertexFinder::InitRun(int runnumber){
   St_db_Maker* mydb = (St_db_Maker*) StMaker::GetChain()->GetMaker("db");
   int dateY=mydb->GetDateTime().GetYear();
   
-  if(mIsMC) assert(runnumber <1000000); // probably embeding job ,crash it, JB
  // Initialize BTOF geometry
   if (mUseBtof){ // only add btof if it is required
     btofGeom = 0;
@@ -172,7 +170,11 @@ StPPVertexFinder::InitRun(int runnumber){
   }
 
   //.. set various params 
-  if (!mIsMC && runnumber < 13000000) {
+  // It is not clear why one would hard code cuts for any specific run or
+  // a period since they can be set in the database. Here we'll assume that for
+  // Runs 5 to 12 the PPV cuts are optimized and there is no need to access the
+  // values from the database.
+  if (runnumber >= 6000000 && runnumber < 13000000) {
     // old defaults, pre-Run12
     // (important if we want to reprocess old data with different cuts!)
     LOG_INFO << "PPV InitRun() using old, hardwired cuts" << endm;
@@ -197,20 +199,6 @@ StPPVertexFinder::InitRun(int runnumber){
   mMinAdcEemc   = 5;    // chan, MIP @ 6-18 ADC depending on eta
 
   //assert(dateY<2008); // who knows what 2007 setup will be,  crash it just in case
-  if(mIsMC) {
-    LOG_INFO << "PPV InitRun() M-C, Db_date="<<mydb->GetDateTime().AsString()<<endm;
-    // simu prior to 2008 
-    mMinAdcBemc =7; //ideal BTOW gain 60 GeV ET @ 3500 ADC 
-    // in late 2008 Matt uploaded ideal (aka sim) gians matching endcap
-    if(dateY>=2008)  mMinAdcBemc =8; //ideal BTOW gain 60 GeV ET @ 4076 ADC
-
-    if(dateY>2006) {
-       LOG_WARN << "PPV InitRun() , M-C time stamp differs from 2005,\n"
-          "BTOW status tables questionable,\n PPV results qauestionable,\n\n"
-          "F I X    B T O W    S T A T U S     T A B L E S     B E F O R E     U S E  !!!\n\n"
-          "chain will continue taking whatever is loaded in to DB\n  Jan Balewski, January 2006\n" << endm;
-    }
-  }
 
   if(dateY<2006) {
     mMinAdcBemc   = 15;   // BTOW used calibration of maxt Et @ ~27Gev 
@@ -245,7 +233,6 @@ StPPVertexFinder::InitRun(int runnumber){
     <<"\n Min/Max Z position for BTOF hit = " << mMinZBtof<<" "<<mMaxZBtof   
     <<"\n MinAdcBemc for MIP = " << mMinAdcBemc
     <<"\n MinAdcEemc for MIP = " << mMinAdcEemc
-    <<"\n bool    mIsMC = " << mIsMC
     <<"\n bool  useCtb = " << mUseCtb
     <<"\n bool useBtof = " << mUseBtof
     <<"\n bool nFit/nPoss weighting = " << mFitPossWeighting
@@ -363,26 +350,6 @@ StPPVertexFinder::printInfo(ostream& os) const
 
   float zGeant=999;
   
-  if(mIsMC) {
-    // get geant vertex
-    St_DataSet *gds=StMaker::GetChain()->GetDataSet("geant");
-    assert(gds);
-    St_g2t_vertex  *g2t_ver=( St_g2t_vertex *)gds->Find("g2t_vertex");
-    if(g2t_ver) {
-      // --------------  A C C E S S    G E A N T   V E R T E X  (for histo)
-      g2t_vertex_st *GVER= g2t_ver->GetTable();
-      zGeant=GVER->ge_x[2];
-      printf("#GVER z=%.1f x=%.1f y=%.1f  nEve=%d nV=%d ",zGeant,GVER->ge_x[0],GVER->ge_x[1],mTotEve,mVertexData.size());  
-    }
-  }
-  
-  if(mIsMC) {
-    for (const TrackData &t : mTrackData) {
-      if(t.vertexID<=0) continue; // skip not used or pileup vertex
-      hA[12]->Fill(zGeant-t.zDca);
-    }
-  }
-   
   LOG_DEBUG<< Form("---- end of PPVertex Info\n")<<endm;
 
 }
@@ -436,13 +403,8 @@ StPPVertexFinder::fit(StEvent* event) {
 
   // get CTB info, does not  work for embeding 
   if(mUseCtb) {// CTB could be off since 2006 
-    if(mIsMC){
-      St_DataSet *gds=StMaker::GetChain()->GetDataSet("geant");
-      ctbList->buildFromMC(gds);  // use M-C
-    }  else {
-      StTriggerData *trgD=event->triggerData ();
-      ctbList->buildFromData(trgD); // use real data
-    }
+    StTriggerData *trgD=event->triggerData ();
+    ctbList->buildFromData(trgD); // use real data
   }
 
   

--- a/StGenericVertexMaker/StvPPVertex/StPPVertexFinder.cxx
+++ b/StGenericVertexMaker/StvPPVertex/StPPVertexFinder.cxx
@@ -82,7 +82,6 @@ StPPVertexFinder::StPPVertexFinder()
   mToolkit =0;
   memset(hA,0,sizeof(hA));
 
-  setMC(false);                      	// default = real Data
   UseCTB(false);                      	// default CTB is off
   UseBTOF(false);                      	// default BTOF is off
   setDropPostCrossingTrack(true);    	// default PCT rejection on
@@ -154,7 +153,6 @@ void StPPVertexFinder::InitRun(int runnumber)
   St_db_Maker* mydb = (St_db_Maker*) StMaker::GetChain()->GetMaker("db");
   int dateY=mydb->GetDateTime().GetYear();
   
-  if(mIsMC) assert(runnumber <1000000); // probably embeding job ,crash it, JB
  // Initialize BTOF geometry
   if (mUseBtof){ // only add btof if it is required
     btofGeom = 0;
@@ -176,7 +174,11 @@ void StPPVertexFinder::InitRun(int runnumber)
   }
 
   //.. set various params 
-  if (!mIsMC && runnumber < 13000000) {
+  // It is not clear why one would hard code cuts for any specific run or
+  // a period since they can be set in the database. Here we'll assume that for
+  // Runs 5 to 12 the PPV cuts are optimized and there is no need to access the
+  // values from the database.
+  if (runnumber >= 6000000 && runnumber < 13000000) {
     // old defaults, pre-Run12
     // (important if we want to reprocess old data with different cuts!)
     LOG_INFO << "PPV InitRun() using old, hardwired cuts" << endm;
@@ -201,16 +203,6 @@ void StPPVertexFinder::InitRun(int runnumber)
   mMinAdcEemc   = 5;    // chan, MIP @ 6-18 ADC depending on eta
 
   //assert(dateY<2008); // who knows what 2007 setup will be,  crash it just in case
-  if(mIsMC) {
-    LOG_INFO << "PPV InitRun() M-C, Db_date="<<mydb->GetDateTime().AsString()<<endm;
-    // simu prior to 2008 
-    mMinAdcBemc =7; //ideal BTOW gain 60 GeV ET @ 3500 ADC 
-    // in late 2008 Matt uploaded ideal (aka sim) gians matching endcap
-    if(dateY>=2008)  mMinAdcBemc =8; //ideal BTOW gain 60 GeV ET @ 4076 ADC
-
-    if(dateY>2006)  LOG_WARN <<
-	  "PPV InitRun() , M-C time stamp differs from 2005,\n BTOW status tables questionable,\n PPV results qauestionable, \n\n  F I X    B T O W    S T A T U S     T A B L E S     B E F O R E     U S E  !!!  \n \n chain will continue taking whatever is loaded in to DB\n  Jan Balewski, January 2006\n"<<endm; 
-  }
 
   if(dateY<2006) {
     mMinAdcBemc   = 15;   // BTOW used calibration of maxt Et @ ~27Gev 
@@ -245,7 +237,6 @@ void StPPVertexFinder::InitRun(int runnumber)
     <<"\n Min/Max Z position for BTOF hit = " << mMinZBtof<<" "<<mMaxZBtof   
     <<"\n MinAdcBemc for MIP = " << mMinAdcBemc
     <<"\n MinAdcEemc for MIP = " << mMinAdcEemc
-    <<"\n bool    mIsMC = " << mIsMC
     <<"\n bool  useCtb = " << mUseCtb
     <<"\n bool useBtof = " << mUseBtof
     <<"\n bool nFit/nPoss weighting = " << mFitPossWeighting
@@ -370,27 +361,6 @@ void StPPVertexFinder::printInfo(ostream& os) const
   }
   float zGeant=999;
   
-  if(mIsMC) {
-    // get geant vertex
-    St_DataSet *gds=StMaker::GetChain()->GetDataSet("geant");
-    assert(gds);
-    St_g2t_vertex  *g2t_ver=( St_g2t_vertex *)gds->Find("g2t_vertex");
-    if(g2t_ver) {
-      // --------------  A C C E S S    G E A N T   V E R T E X  (for histo)
-      g2t_vertex_st *GVER= g2t_ver->GetTable();
-      zGeant=GVER->ge_x[2];
-      printf("#GVER z=%.1f x=%.1f y=%.1f  nEve=%d nV=%d ",zGeant,GVER->ge_x[0],GVER->ge_x[1],mTotEve,mVertexData.size());  
-    }
-  }
-  
-  if(mIsMC) {
-    for(i=0;i<mTrackData.size();i++) {
-      const TrackData *t=&mTrackData[i];
-      if(t->vertexID<=0) continue; // skip not used or pileup vertex 
-      hA[12]->Fill(zGeant-t->zDca);
-    }
-  }
-   
   LOG_DEBUG<< Form("---- end of PPVertex Info\n")<<endm;
 
 }
@@ -441,13 +411,8 @@ assert(event);
 
   // get CTB info, does not  work for embeding 
   if(mUseCtb) {// CTB could be off since 2006 
-    if(mIsMC){
-      St_DataSet *gds=StMaker::GetChain()->GetDataSet("geant");
-      ctbList->buildFromMC(gds);  // use M-C
-    }  else {
-      StTriggerData *trgD=event->triggerData ();
-      ctbList->buildFromData(trgD); // use real data
-    }
+    StTriggerData *trgD=event->triggerData ();
+    ctbList->buildFromData(trgD); // use real data
   }
 
   


### PR DESCRIPTION
Removed mIsMC flag in order to treat the simulated and real data in the same
manner during vertex reconstruction. The flag caused confusion rather than being
helpful in any way for the main VF task. As an additional benefit the users will
not have to worry about setting the flag when running on simulated data.